### PR TITLE
Enable error return trace by using `anyhow`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aho-corasick"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15,6 +30,7 @@ dependencies = [
 name = "ailurus-kv"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "bytes",
  "crc32fast",
  "env_logger",
@@ -31,12 +47,30 @@ name = "anyhow"
 version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
+dependencies = [
+ "backtrace",
+]
 
 [[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "backtrace"
+version = "0.3.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
 
 [[package]]
 name = "bitflags"
@@ -119,6 +153,12 @@ checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.27.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
 
 [[package]]
 name = "hermit-abi"
@@ -214,6 +254,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+dependencies = [
+ "adler",
+]
+
+[[package]]
+name = "object"
+version = "0.30.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03b4680b86d9cfafba8fc491dc9b6df26b68cf40e9e6cd73909194759a63c385"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -302,6 +360,12 @@ name = "regex-syntax"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustix"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = { version = "1.0.71", features = ["backtrace"] }
 bytes = "1.4.0"
 crc32fast = "1.3.2"
 env_logger = "0.10.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,6 @@ parking_lot = "0.12.1"
 prost = "0.11.9"
 tempfile = "3.6.0"
 thiserror = "1.0.40"
+
+[features]
+debug = []

--- a/src/data/data_file.rs
+++ b/src/data/data_file.rs
@@ -26,7 +26,7 @@ impl DataFile {
             }
             false => {
                 error!("Database dir {:?} Not exist", fname);
-                return Err(Errors::DatafileNotFound);
+                return Err(Errors::DatafileNotFound.into());
             }
         };
 
@@ -40,7 +40,7 @@ impl DataFile {
                 .len(),
             Err(e) => {
                 error!("{}", e);
-                return Err(Errors::FailToOpenFile);
+                return Err(Errors::FailToOpenFile.into());
             }
         };
 
@@ -118,7 +118,7 @@ impl DataFile {
 
         if crc != log_record.crc() {
             error!("CRC does not match");
-            return Err(Errors::DatafileCorrupted);
+            return Err(Errors::DatafileCorrupted.into());
         }
 
         Ok(Some(log_record))

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -32,4 +32,7 @@ pub enum Errors {
     InternalError,
 }
 
+#[cfg(not(feature = "debug"))]
 pub type Result<T> = std::result::Result<T, Errors>;
+#[cfg(feature = "debug")]
+pub type Result<T> = anyhow::Result<T, anyhow::Error>;

--- a/src/fio/fio.rs
+++ b/src/fio/fio.rs
@@ -27,7 +27,7 @@ impl FileIO {
             }),
             Err(e) => {
                 error!("{}", e);
-                Err(Errors::FailToOpenFile)
+                Err(Errors::FailToOpenFile.into())
             }
         };
     }
@@ -38,7 +38,7 @@ impl IOManager for FileIO {
         let reader = self.fd.read();
         reader.read_exact_at(buf, offset).map_err(|e| {
             error!("{}", e);
-            Errors::FailToReadFromFile
+            Errors::FailToReadFromFile.into()
         })
     }
 
@@ -48,7 +48,7 @@ impl IOManager for FileIO {
             Ok(n) => Ok(n),
             Err(e) => {
                 error!("{}", e);
-                Err(Errors::FailToWriteToFile)
+                Err(Errors::FailToWriteToFile.into())
             }
         };
     }
@@ -57,7 +57,7 @@ impl IOManager for FileIO {
         let reader = self.fd.read();
         if let Err(e) = reader.sync_all() {
             error!("{}", e);
-            return Err(Errors::FailToSyncFile);
+            return Err(Errors::FailToSyncFile.into());
         }
         Ok(())
     }
@@ -90,7 +90,10 @@ mod tests {
 
         let mut buf = vec![0; data.len()];
         let result = file.read(&mut buf, 0);
+        #[cfg(not(feature = "debug"))]
         assert_eq!(result, Ok(()));
+        #[cfg(feature = "debug")]
+        assert_eq!(result.unwrap(), ());
         assert_eq!(buf, data);
 
         fs::remove_file(&file_path).unwrap();
@@ -103,7 +106,10 @@ mod tests {
         let data = b"Hello, World!";
 
         let result = file.write(data);
+        #[cfg(not(feature = "debug"))]
         assert_eq!(result, Ok(data.len()));
+        #[cfg(feature = "debug")]
+        assert_eq!(result.unwrap(), data.len());
 
         let mut buf = vec![0; data.len()];
         let _ = file.sync();

--- a/src/options.rs
+++ b/src/options.rs
@@ -20,11 +20,11 @@ pub struct Options {
 
 pub(crate) fn check_options(opts: &Options) -> Result<()> {
     if opts.dir_path.to_str().is_none() {
-        return Err(Errors::InvalidDbPath);
+        return Err(Errors::InvalidDbPath.into());
     }
 
     if opts.data_file_size == 0 {
-        return Err(Errors::DatafileSizeTooSmall);
+        return Err(Errors::DatafileSizeTooSmall.into());
     }
 
     Ok(())


### PR DESCRIPTION
This PR add `anyhow` as deps to fix the problem that error is hard to trace when debugging.
To enable this feature, simply add `debug` cfg flags:
```sh
cargo test --features debug
```